### PR TITLE
Add systemd service file for autorestart on error

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,63 @@
+# Installing RadBot as a Systemd Service
+
+(These instructions were tested on Ubuntu 20.04 LTS)
+
+1. Create a non-root user to run the RadBot process
+
+    ```
+    useradd -m -s /bin/bash radbot
+    ```
+
+2. Copy all the RadBot files into the radbot user home directory
+
+    ```
+    /home/radbot/RadBot/
+    ```
+
+3. Copy the radbot.service file into /etc/systemd/system/
+
+    ```
+    sudo cp radbot.service /etc/systemd/system/
+    ```
+
+    The service file is configured to run as the radbot user and group and use
+    /home/radbot/RadBot as the working directory. You shouldn't need to change any
+    configuration values if you've set up the radbot user as above.
+
+
+4. Let systemd know about the new service file by running:
+
+    ```
+    sudo systemctl daemon-reload
+    ```
+
+5. Start the radbot service:
+
+    ```
+    sudo systemctl start radbot
+    ```
+
+6. Check the running status as follows:
+
+    ```
+    sudo systemctl status radbot
+    ```
+
+    You should see something similar to below:
+
+    ```
+    ● radbot.service - RadBot Service
+     Loaded: loaded (/etc/systemd/system/radbot.service; enabled; vendor preset: enabled)
+     Active: active (running) since Mon 2021-03-15 17:16:17 UTC; 4s ago
+   Main PID: 105129 (python3.9)
+      Tasks: 11 (limit: 76859)
+     Memory: 97.9M
+     CGroup: /system.slice/radbot.service
+             └─105129 /usr/bin/python /home/radbot/RadBot/RadBot.py
+    ```
+
+7. If the bot runs successfully, then enable the service as follows so that it will automatically start up on server reboot:
+
+    ```
+    sudo systemctl enbable radbot
+    ```

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -59,5 +59,5 @@
 7. If the bot runs successfully, then enable the service as follows so that it will automatically start up on server reboot:
 
     ```
-    sudo systemctl enbable radbot
+    sudo systemctl enable radbot
     ```

--- a/systemd/radbot.service
+++ b/systemd/radbot.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=RadBot Service
+After=multi-user.target
+Conflicts=getty@tty1.service
+
+[Service]
+Type=simple
+User=radbot
+Group=radbot
+WorkingDirectory=/home/radbot/RadBot
+ExecStart=/usr/bin/python /home/radbot/RadBot/RadBot.py
+StandardInput=tty-force
+Restart=always
+RestartSec=5
+
+# Specifies which signal to use when killing a service. Defaults to SIGTERM.
+# SIGHUP gives radbot time to exit cleanly before SIGKILL (default 90s)
+KillSignal=SIGHUP
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds a systemd service file that will allow RadBot to run as a daemon/service. The main benefit is that the process will be automatically restarted if it crashes.